### PR TITLE
Refactor payment method logic in transaction processing

### DIFF
--- a/app/routes/till/transaction.js
+++ b/app/routes/till/transaction.js
@@ -359,8 +359,8 @@ router.post(
 
         formattedTransaction.summary.discount_info = discountInfo;
 
-        if (payWithTokens == true) {
-          if (totalMoney == 0) {
+        if (payWithTokens === true) {
+          if (totalMoney === 0) {
             if (member.balance >= totalTokens) {
               totals.tokens = Math.ceil(totalTokens);
             } else {
@@ -384,10 +384,6 @@ router.post(
           }
         } else {
           totals.money = (Number(totalTokens) + Number(totalMoney)).toFixed(2);
-        }
-
-        if (totals.money == 0 && totals.tokens == 0) {
-          paymentMethod = null;
         }
       } else {
         totals.money = (Number(totalTokens) + Number(totalMoney)).toFixed(2);
@@ -415,12 +411,11 @@ router.post(
           };
           formattedTransaction.summary.bill.push(automaticDonation);
         }
-
-        if (totals.money == 0) {
-          paymentMethod = null;
-        }
       }
 
+      if (!Number(totals.money)) {
+        paymentMethod = null;
+      }
       formattedTransaction.summary.totals = totals;
       formattedTransaction.summary.paymentMethod = paymentMethod;
 


### PR DESCRIPTION
- Simplified the condition for setting paymentMethod to null when both totals.money and totals.tokens are zero.

This fixes a bug where a member who did not pay with tokens could not have their transaction processed via 'Pay Nothing' option.