### PR TITLE
Only show not quantity for quantity

### DIFF
--- a/app/views/partials/till/transaction.hbs
+++ b/app/views/partials/till/transaction.hbs
@@ -546,7 +546,7 @@ function updateTransactionList(){
 
 		let inputBoxWidth = 80;
     
-    if(transaction[i].action == null && transaction[i].discount == false){
+    if(transaction[i].action !== "giftcard" && transaction[i].discount == false){
       var quantityColumnInput = document.createElement("input");
 
       let maxQuantity;


### PR DESCRIPTION
Fix a bug where discounts on develop could show as a zero amount but then show as a non-zero amount when a card-transaction is processed.